### PR TITLE
Remove unnecessary reference to Xamarin.Essentials

### DIFF
--- a/Xam.Plugin.SimpleBottomDrawer/Xam.Plugin.SimpleBottomDrawer.csproj
+++ b/Xam.Plugin.SimpleBottomDrawer/Xam.Plugin.SimpleBottomDrawer.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.Forms" Version="4.7.0.1080" />
   </ItemGroup>
 


### PR DESCRIPTION
Hey,

I found your plugin through [this repository](https://github.com/alexandresanlim/XamarinUI.DashboardDrawer) on [snppts.dev](https://www.snppts.dev/). Just what I was looking for, thanks for sharing!

However, I noticed it is referencing Xamarin.Essentials and saw that it does not make use of it anywhere.
In order to reduce dependencies as much as possible, I think it can be removed. Filed this pull request for your convenience.

Cheers

David