### PR TITLE
[bugfix] scroll-to-fullscreen issue workaround

### DIFF
--- a/Samples/Xam.Plugin.SimpleBottomDrawer.Samples/Xam.Plugin.SimpleBottomDrawer.Samples/MainPage.xaml
+++ b/Samples/Xam.Plugin.SimpleBottomDrawer.Samples/Xam.Plugin.SimpleBottomDrawer.Samples/MainPage.xaml
@@ -50,6 +50,7 @@
                 ExpandedPercentage="{Binding ExpandedPercentage}"
                 IsExpanded="{Binding IsExpanded}"
                 IsVisible="{Binding IsVisible}"
+                LockStates="{Binding LockStates}"
                 RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent,
                                                                        Property=Height,
                                                                        Factor=1,

--- a/Samples/Xam.Plugin.SimpleBottomDrawer.Samples/Xam.Plugin.SimpleBottomDrawer.Samples/ViewModel/MainPageViewModel.cs
+++ b/Samples/Xam.Plugin.SimpleBottomDrawer.Samples/Xam.Plugin.SimpleBottomDrawer.Samples/ViewModel/MainPageViewModel.cs
@@ -38,8 +38,10 @@ namespace Xam.Plugin.SimpleBottomDrawer.Samples.ViewModel
 
         /// <summary>
         /// The bottom drawer lock states
+        ///
+        /// Note: [alex-d] works incorrectly when more than 3 values
         /// </summary>
-        private double[] _LockStates = new double[] { 0, .50, 0.75 };
+        private double[] _LockStates = new double[] { 0, .30, 0.6, 0.95 };
 
         #endregion
 

--- a/Samples/Xam.Plugin.SimpleBottomDrawer.Samples/Xam.Plugin.SimpleBottomDrawer.Samples/ViewModel/MainPageViewModel.cs
+++ b/Samples/Xam.Plugin.SimpleBottomDrawer.Samples/Xam.Plugin.SimpleBottomDrawer.Samples/ViewModel/MainPageViewModel.cs
@@ -40,8 +40,10 @@ namespace Xam.Plugin.SimpleBottomDrawer.Samples.ViewModel
         /// The bottom drawer lock states
         ///
         /// Note: [alex-d] works incorrectly when more than 3 values
+        /// private double[] _LockStates = new double[] { 0, .30, 0.6, 0.95 };
         /// </summary>
-        private double[] _LockStates = new double[] { 0, .30, 0.6, 0.95 };
+        private double[] _LockStates = new double[] { 0, .50, 0.75 };
+        
 
         #endregion
 

--- a/Xam.Plugin.SimpleBottomDrawer/BottomDrawer.cs
+++ b/Xam.Plugin.SimpleBottomDrawer/BottomDrawer.cs
@@ -312,16 +312,16 @@ namespace Xam.Plugin.SimpleBottomDrawer
         {
             System.Console.WriteLine("[BottomDrawer] OnTapped()");
 
-            if (!IsExpanded)
+            if (!this.IsExpanded)
             {
                 if (this.LockStates.Length >= 2)
                 {
                     // TODO: [alex-d] why hard-coded [1] index?
                     // -
-                    ExpandedPercentage = LockStates[1];
+                    this.ExpandedPercentage = LockStates[1];
                 }
 
-                IsExpanded = ExpandedPercentage > 0;
+                this.IsExpanded = (this.ExpandedPercentage > 0);
             }
         }
 
@@ -357,7 +357,7 @@ namespace Xam.Plugin.SimpleBottomDrawer
             }
 
             double result = LockStates[closestIndex];
-            System.Console.WriteLine($"[BottomDrawer] GetClosestLockState() | result=={result} | index=={closestIndex}");
+            System.Console.WriteLine($"[BottomDrawer] GetClosestLockState() | current=={current} | result=={result} | index=={closestIndex} | TranslationY=={TranslationY}");
 
             return result;
         }
@@ -388,9 +388,7 @@ namespace Xam.Plugin.SimpleBottomDrawer
         /// </summary>
         public void Dismiss()
         {
-            System.Console.WriteLine("[BottomDrawer] Dismiss()");
-
-            var finalTranslation =
+            double finalTranslation =
                 Math.Max(
                        Math.Min(0, -1000)
                     , -Math.Abs(getProportionCoordinate(LockStates[0]))
@@ -405,6 +403,8 @@ namespace Xam.Plugin.SimpleBottomDrawer
                         ? Easing.SpringOut
                         : null
             );
+
+            System.Console.WriteLine($"[BottomDrawer] Dismiss() | finalTranslation=={finalTranslation}");
         }
 
         /// <summary>
@@ -412,9 +412,7 @@ namespace Xam.Plugin.SimpleBottomDrawer
         /// </summary>
         public void Open()
         {
-            System.Console.WriteLine("[BottomDrawer] Open()");
-
-            var finalTranslation =
+            double finalTranslation =
                 Math.Max(
                       Math.Min(0, -1000)
                     , -Math.Abs(getProportionCoordinate(LockStates[LockStates.Length - 1]))
@@ -429,6 +427,8 @@ namespace Xam.Plugin.SimpleBottomDrawer
                         ? Easing.SpringIn
                         : null
             );
+
+            System.Console.WriteLine($"[BottomDrawer] Open() | finalTranslation=={finalTranslation}");
         }
 
         #endregion Public


### PR DESCRIPTION
* Addressing issue #11 
* Added debug logs (with `System.Console.WriteLine()`)
* Introduced `GetClosestLockStateAbsolute` and `GetClosestLockStatePercentage` to use a cached value of `ExpandedPercentage` and avoid some number mismatches

P.S. For some reason I could not reproduce the issue for the sample project and I've failed to make my own non-NDA sample. Publishing this PR just in case anyone else faces this issue, please feel free using this patch at your own risk.