### PR TITLE
[lock state] reuse previously calculated ExpandedPercentage

### DIFF
--- a/Xam.Plugin.SimpleBottomDrawer/BottomDrawer.cs
+++ b/Xam.Plugin.SimpleBottomDrawer/BottomDrawer.cs
@@ -316,14 +316,10 @@ namespace Xam.Plugin.SimpleBottomDrawer
                             , easing: Easing.SpringOut);
                     }
 
-                    // Note: [alex-d] this.TranslationY might change due to this.TranslateTo()
+                    // Note: [alex-d] |this.TranslationY| seems to not change due to |this.TranslateTo()|
+                    //       so it is ok to reuse the |tmpLockState| value
                     // -
-                    double dragDistanceY2 = e.TotalY + this.TranslationY;
-
-#if DEBUG
-                    System.Console.WriteLine($"[BottomDrawer] OnPanChanged() - call#2 GetClosestLockState({dragDistanceY2})");
-#endif
-                    this.ExpandedPercentage = GetClosestLockStateAbsolute(dragDistanceY2);
+                    this.ExpandedPercentage = tmpLockState;
                     this.isDragging = false;
 
 #if DEBUG


### PR DESCRIPTION
```c#
double dragDistanceY2 = e.TotalY + this.TranslationY;
this.ExpandedPercentage = GetClosestLockStateAbsolute(dragDistanceY2);
```

Why do we have a `GetClosestLockState` called here again? 
https://github.com/galadril/Xam.Plugin.SimpleBottomDrawer/blob/master/Xam.Plugin.SimpleBottomDrawer/BottomDrawer.cs#L321

Is it expected to update after some `this.TranslateTo()` call above? Or is that just a copy-paste of the code above?
I have another issue and using the same `GetClosestLockStatePercentage(this.ExpandedPercentage);` instruction again **solves it**. Asking just to make sure this change is safe to introduce.

P.S. Seems like `e.TotalY + this.TranslationY;` is not changed after `this.TranslateTo()` call, so I'm assuming "just a copy-paste" hypothesis is a correct one. The fact that **after the fix everything works for me** - seems to confirm my guess. 